### PR TITLE
fix(utils): reduce call stack size when scanning project files

### DIFF
--- a/src/utils/import.utils.ts
+++ b/src/utils/import.utils.ts
@@ -41,9 +41,13 @@ export function findDeclarationFileByName(host: Tree, name: string): string[] {
   }
 
   if (!hostFiles) {
-    hostFiles = createFilesArrayFromDir(host.getDir('.')).filter(
-      f => !f.endsWith('spec.ts') && f.endsWith('.ts') && !f.startsWith('/node_modules')
-    );
+    hostFiles = createFilesArrayFromDir(
+      host.getDir('.'),
+      dirEntry =>
+        !dirEntry.path.startsWith('/node_modules') &&
+        !dirEntry.path.startsWith('/.') &&
+        !dirEntry.path.startsWith('/dist')
+    ).filter(f => !f.endsWith('spec.ts') && f.endsWith('.ts'));
     schematicCache.save('hostFiles', hostFiles);
   }
 

--- a/src/utils/ts.utils.ts
+++ b/src/utils/ts.utils.ts
@@ -25,14 +25,24 @@ export function showTree(node: ts.Node, indent: string = '    '): void {
   }
 }
 
-export function createFilesArrayFromDir(dir: DirEntry): string[] {
-  const dirFiles = dir.subfiles.map(subFile => normalize(`${dir.path}/${subFile}`));
+export function createFilesArrayFromDir(
+  dir: DirEntry,
+  dirFilterFn: (d: DirEntry) => boolean = () => true
+): string[] {
+  let files: string[] = [];
+  const directoriesToScan = [dir];
 
-  dir.subdirs.forEach(subDir => {
-    dirFiles.push(...createFilesArrayFromDir(dir.dir(subDir)));
-  });
+  while (directoriesToScan.length) {
+    const currentDir = directoriesToScan.shift() as DirEntry;
+    files = files.concat(
+      currentDir.subfiles.map(subFile => normalize(`${currentDir.path}/${subFile}`))
+    );
+    directoriesToScan.push(
+      ...currentDir.subdirs.map(subdir => currentDir.dir(subdir)).filter(dirFilterFn)
+    );
+  }
 
-  return dirFiles;
+  return files;
 }
 
 export function findDeclarationNodeByName<T extends ts.Node>(


### PR DESCRIPTION
This avoids "maximum call stack exceeded size" error and improves performance.